### PR TITLE
asynchronous operations fix

### DIFF
--- a/custom_components/petnovations/__init__.py
+++ b/custom_components/petnovations/__init__.py
@@ -24,3 +24,4 @@ async def async_setup_entry(hass, config_entry):
             config_entry,
         )
     return True
+

--- a/custom_components/petnovations/api.py
+++ b/custom_components/petnovations/api.py
@@ -1,34 +1,36 @@
-import requests
+import aiohttp
 from typing import Optional
+import asyncio
 
 class PetnovationsAPI:
     def __init__(self, refresh_token: str):
         self.refresh_token = refresh_token
         self.token = None
-        self.token_expiry = None
 
-    def _get_new_token(self) -> Optional[str]:
+    async def _get_new_token(self) -> Optional[str]:
         url = "https://iot.petnovations.com/facade/v1/mobile-user/refreshToken"
-        response = requests.post(url, json={"refreshToken": self.refresh_token})
-        if response.status_code == 200:
-            data = response.json()
-            self.token = data.get("token")
-            # Handle token expiry logic if needed
-            return self.token
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json={"refreshToken": self.refresh_token}) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    self.token = data.get("token")
+                    return self.token
         return None
 
-    def _request_with_token(self, url: str, method: str = 'GET', data: Optional[dict] = None):
+    async def _request_with_token(self, url: str, method: str = 'GET', data: Optional[dict] = None):
         headers = {
             "Authorization": f"Bearer {self.token}"
         }
-        response = requests.request(method, url, headers=headers, json=data)
-        if response.status_code == 401 and response.json().get("code") == "TOKEN_NOT_VALID":
-            # Token expired, refresh token
-            self._get_new_token()
-            headers["Authorization"] = f"Bearer {self.token}"
-            response = requests.request(method, url, headers=headers, json=data)
-        return response.json()
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, json=data) as response:
+                if response.status == 401 and (await response.json()).get("code") == "TOKEN_NOT_VALID":
+                    # Token expired, refresh token
+                    await self._get_new_token()
+                    headers["Authorization"] = f"Bearer {self.token}"
+                    async with session.request(method, url, headers=headers, json=data) as retry_response:
+                        return await retry_response.json()
+                return await response.json()
 
-    def get_devices(self):
+    async def get_devices(self):
         url = "https://iot.petnovations.com/device/device"
-        return self._request_with_token(url)
+        return await self._request_with_token(url)

--- a/custom_components/petnovations/config_flow.py
+++ b/custom_components/petnovations/config_flow.py
@@ -14,7 +14,7 @@ class PetnovationsConfigFlow(config_entries.ConfigFlow, domain="petnovations"):
         if user_input is not None:
             refresh_token = user_input[CONF_REFRESH_TOKEN]
             api = PetnovationsAPI(refresh_token)
-            token = api._get_new_token()
+            token = await api._get_new_token()
             if token:
                 return self.async_create_entry(
                     title="Petnovations",


### PR DESCRIPTION
The error you’re encountering is because Home Assistant’s event loop is blocking due to the synchronous requests library call. Home Assistant is built on asynchronous principles and prefers asynchronous operations to avoid blocking the event loop.

You need to replace synchronous HTTP calls with asynchronous ones. This can be done using the aiohttp library, which is designed for asynchronous HTTP operations.